### PR TITLE
feat: add system property for whoami timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,9 @@ to improve container creation reliability.
 - `io.jenkins.plugins.kubernetes.ephemeral.EphemeralContainerStepExecution.patchRetryMaxWaitSecs`
   > Max wait time between retries. Used to minimize patch conflicts.
   > > Default: `2`
+- `io.jenkins.plugins.kubernetes.ephemeral.EphemeralContainerStepExecution.whoamiTimeoutSecs`
+  > Client timeout for running commands to determine the user and group id when not specified by the template.
+  > > Default: `180`
 
 ## Metrics
 

--- a/src/main/java/io/jenkins/plugins/kubernetes/ephemeral/EphemeralContainerStepExecution.java
+++ b/src/main/java/io/jenkins/plugins/kubernetes/ephemeral/EphemeralContainerStepExecution.java
@@ -89,6 +89,8 @@ public class EphemeralContainerStepExecution extends GeneralNonBlockingStepExecu
     private static final int START_RETRY_MAX_WAIT =
             Integer.getInteger(EphemeralContainerStepExecution.class.getName() + ".startRetryMaxWaitSecs", 2);
     private static final Set<String> START_RETRY_REASONS = Collections.singleton("StartError");
+    private static final int WHOAMI_TIMEOUT =
+            Integer.getInteger(EphemeralContainerStepExecution.class.getName() + ".whoamiTimeoutSecs", 180);
 
     @SuppressFBWarnings(value = "SE_TRANSIENT_FIELD_NOT_RESTORED", justification = "not needed on deserialization")
     private final transient EphemeralContainerStep step;
@@ -441,7 +443,7 @@ public class EphemeralContainerStepExecution extends GeneralNonBlockingStepExecu
                     .quiet(true)
                     .stdout(userId)
                     .start()
-                    .joinWithTimeout(60, TimeUnit.SECONDS, launcher.getListener());
+                    .joinWithTimeout(WHOAMI_TIMEOUT, TimeUnit.SECONDS, launcher.getListener());
 
             ByteArrayOutputStream groupId = new ByteArrayOutputStream();
             launcher.launch()
@@ -449,7 +451,7 @@ public class EphemeralContainerStepExecution extends GeneralNonBlockingStepExecu
                     .quiet(true)
                     .stdout(groupId)
                     .start()
-                    .joinWithTimeout(60, TimeUnit.SECONDS, launcher.getListener());
+                    .joinWithTimeout(WHOAMI_TIMEOUT, TimeUnit.SECONDS, launcher.getListener());
 
             final Charset charset = Charset.defaultCharset();
             sc.setRunAsUser(NumberUtils.createLong(userId.toString(charset).trim()));


### PR DESCRIPTION
This change adds an advanced system property to control the timeout seconds used for running the whoami commands when not specified. The default value is increased from 60 to 180 seconds.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
