### PR TITLE
feat: exit early on image pull error

### DIFF
--- a/src/main/java/io/jenkins/plugins/kubernetes/ephemeral/ImageReference.java
+++ b/src/main/java/io/jenkins/plugins/kubernetes/ephemeral/ImageReference.java
@@ -44,7 +44,7 @@ public class ImageReference {
      * responsibility of the cluster.
      *
      * @param reference reference string, not null
-     * @return image reference or empty if invalid refence format
+     * @return image reference or empty if invalid reference format
      */
     public static Optional<ImageReference> parse(@NonNull String reference) {
         String digest = null;

--- a/src/test/java/io/jenkins/plugins/kubernetes/ephemeral/it/KubernetesTunnelExtension.java
+++ b/src/test/java/io/jenkins/plugins/kubernetes/ephemeral/it/KubernetesTunnelExtension.java
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 
 /**
  * Test extension that exposes from the provided Kubernetes cluster namespace to
- * ths test Jenkins instance running outside the cluster. This tunnel is created
+ * this test Jenkins instance running outside the cluster. This tunnel is created
  * using the <a href="https://github.com/omrikiei/ktunnel">ktunnel</a> command.
  *
  * @see #ktunnelCmd()


### PR DESCRIPTION
This change updates the container wait logic to abort early on ErrImagePull waiting state reason. These are generally non-recoverable and would usually just wait until the timeout expires.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
